### PR TITLE
added suppport for -d --dir to output reports to a particular directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,25 @@ to get the last report on that table                                            
 ```
 
 ### Downloading reports
+
+#### Output directory
+
+By default the reports will be downloaded to the directory you are calling the script **_from_** - **_not_** the directory the script is stored in.
+So for example if you issued the command:
+
+``` zsh
+cd myreports; ghasrd.rb -o myowner -r myrepo -g 5876671
+```
+
+The reports will download to the `myreports` directory
+
+The `-d [DIRECTORY]` or `--dir [DIRECTORY]` option allows you to set where the reports will be downloaded to:
+
+``` zsh
+mkdir ~/myreports; ghasrd.rb -o myowner -r myrepo -g 5876671 -d ~/myreports
+```
+
+will download the reports to the `myreports` directory in your home directory - no matter where you call the script from.
 #### By analysis ID
 
 If you know the ID (or multiple IDs) for an analyis (you can get a list of IDs using the `-l` option), you can use the following command to download the report for each ID:

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ cd myreports; ghasrd.rb -o myowner -r myrepo -g 5876671
 
 the report(s) will be downloaded to the `myreports` directory
 
-The `-d [DIRECTORY]` or `--dir [DIRECTORY]` option allows you to set where the reports will be downloaded to. The follwoing command:
+The `-d [DIRECTORY]` or `--dir [DIRECTORY]` option allows you to set where the reports will be downloaded to. The following command:
 
 ``` zsh
 mkdir ~/myreports; ghasrd.rb -o myowner -r myrepo -g 5876671 -d ~/myreports

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ So for example if you issued the command:
 cd myreports; ghasrd.rb -o myowner -r myrepo -g 5876671
 ```
 
-The report(s) will be downloaded to the `myreports` directory
+the report(s) will be downloaded to the `myreports` directory
 
 The `-d [DIRECTORY]` or `--dir [DIRECTORY]` option allows you to set where the reports will be downloaded to. The follwoing command:
 

--- a/README.md
+++ b/README.md
@@ -109,15 +109,15 @@ So for example if you issued the command:
 cd myreports; ghasrd.rb -o myowner -r myrepo -g 5876671
 ```
 
-The reports will download to the `myreports` directory
+The report(s) will be downloaded to the `myreports` directory
 
-The `-d [DIRECTORY]` or `--dir [DIRECTORY]` option allows you to set where the reports will be downloaded to:
+The `-d [DIRECTORY]` or `--dir [DIRECTORY]` option allows you to set where the reports will be downloaded to. The follwoing command:
 
 ``` zsh
 mkdir ~/myreports; ghasrd.rb -o myowner -r myrepo -g 5876671 -d ~/myreports
 ```
 
-will download the reports to the `myreports` directory in your home directory - no matter where you call the script from.
+will download the report(s) to the `myreports` directory in your home directory - no matter where you call the script from.
 #### By analysis ID
 
 If you know the ID (or multiple IDs) for an analyis (you can get a list of IDs using the `-l` option), you can use the following command to download the report for each ID:

--- a/ghasrd.rb
+++ b/ghasrd.rb
@@ -210,7 +210,7 @@ def get_report(options, report, file_name)
   raise 'Path given is not a directory' unless path.directory?
 
   path += file_name
-  path.open('w') {|f|
+  path.open('w') { |f|
     f.write(response.body)
     puts "  Report Downloaded to #{file_name}"
   }

--- a/ghasrd.rb
+++ b/ghasrd.rb
@@ -210,7 +210,10 @@ def get_report(options, report, file_name)
   raise 'Path given is not a directory' unless path.directory?
 
   path += file_name
-  path.open('w') { |io| io.write(response.body); puts "  Report Downloaded to #{file_name}" }
+  path.open('w') {|f|
+    f.write(response.body)
+    puts "  Report Downloaded to #{file_name}"
+  }
 end
 
 # Main

--- a/ghasrd.rb
+++ b/ghasrd.rb
@@ -37,7 +37,7 @@ class Optparse
 
       opts.on('-d', '--dir DIRECTORY', 'The directory to write the reports to') do |directory|
         options.directory = directory
-        puts "Directory is #{ directory }" 
+        puts "Directory is #{directory}"
       end
 
       opts.on('-o', '--owner OWNER', 'The owner of the repository') do |owner|
@@ -205,13 +205,12 @@ def get_report(options, report, file_name)
   end
 
   path = Pathname.new(options.directory)
-  raise "Directory does not exist" unless path.exist?
+  raise 'Directory does not exist' unless path.exist?
 
-  raise "Path given is not a directory" unless path.directory?
+  raise 'Path given is not a directory' unless path.directory?
 
   path += file_name
-  path.open("w") { |io| io.write(response.body); puts "  Report Downloaded to #{file_name}" }
-
+  path.open('w') { |io| io.write(response.body); puts "  Report Downloaded to #{file_name}" }
 end
 
 # Main

--- a/ghasrd.rb
+++ b/ghasrd.rb
@@ -210,10 +210,10 @@ def get_report(options, report, file_name)
   raise 'Path given is not a directory' unless path.directory?
 
   path += file_name
-  path.open('w') { |f|
+  path.open('w') do |f|
     f.write(response.body)
     puts "  Report Downloaded to #{file_name}"
-  }
+  end
 end
 
 # Main

--- a/ghasrd.rb
+++ b/ghasrd.rb
@@ -194,7 +194,6 @@ end
 
 def get_report(options, report, file_name)
   puts "  Getting SARIF report with ID #{report}..."
-  puts "  Writing output to: #{options.directory}"
 
   response = get_uri(
     URI.parse("#{options.api}/repos/#{options.owner}/#{options.repo}/code-scanning/analyses/#{report}"),
@@ -278,6 +277,8 @@ begin
 
   when 'get'
     puts 'Getting reports...'
+    puts "  Writing output to: #{options.directory}"
+
     options.report_list.each do |report|
       get_report(options, report, "analysis_#{report}.sarif")
     end
@@ -286,6 +287,7 @@ begin
   when 'pr'
     options.pr_list.each do |pr_id|
       puts "Getting SARIF report(s) for PR ##{pr_id} in https://#{options.hostname}/#{options.owner}/#{options.repo}:"
+      puts "  Writing output to: #{options.directory}"
       pr_info = client.pull_request("#{options.owner}/#{options.repo}", pr_id.to_s)
       puts "  HEAD is #{pr_info.head.sha}"
       reports = client.get("/repos/#{options.owner}/#{options.repo}/code-scanning/analyses")
@@ -307,6 +309,7 @@ begin
 
   when 'sha'
     puts 'Getting reports...'
+    puts "  Writing output to: #{options.directory}"
     options.sha_list.each do |sha|
       begin
         commit_info = client.get("/repos/#{options.owner}/#{options.repo}/commits/#{sha}")


### PR DESCRIPTION
This PR adds support for the `-d` and `--dir DIRECTORY` options to output reports to a user defined dfirectory. The default is the directory the script was called from - _**not**_ the directory the script resides in.